### PR TITLE
修证s.yaml文件中的拼写错误

### DIFF
--- a/src/s.yaml
+++ b/src/s.yaml
@@ -26,7 +26,7 @@ services:
         name: "{{ functionName }}"
         description: 'hello world by serverless devs'
         codeUri: './code'
-        cAPort: 9000
+        caPort: 9000
         customRuntimeConfig:
           command:
             - ./target/main


### PR DESCRIPTION
cAPort拼写错误，应为caPort。